### PR TITLE
Enhanced README.md to include install and deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # aia-web
+
+
+## Local Installation
+Python 3 is required for running this module locally. You can install the required packages using the following command:
+```sh
+pip install -r requirements.txt
+```
+
+## Local Deploy
+The module can be deployed locally using the following command:
+```sh
+mkdocs serve
+```
+
+## References
+1. [MkDocs Installation](https://squidfunk.github.io/mkdocs-material/getting-started/#installation)
+2. [MkDocs Live Preview](https://squidfunk.github.io/mkdocs-material/creating-your-site/#previewing-as-you-write)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material


### PR DESCRIPTION
This PR updates README.md to include the local installation and deployment instructions for the module. 
The `mkdocs` package is added under requirements.txt without a version constraint right now.  