### PR TITLE
Use https for Gradescope link

### DIFF
--- a/docs/syllabus.md
+++ b/docs/syllabus.md
@@ -284,4 +284,4 @@ In this course, we will be using Gradescope (a tool accessed through our Canvas 
 
 During the semester, students will use Gradescope to submit group quiz assignments. To access Gradescope, simply log on to our course’s Canvas site and click on the Gradescope assignment link(s). All Gradescope assignments will be in the form of quiz questions with multiple choice, select all that apply, fill in the blank, short free form responses, and file uploads type questions. All submissions will be reviewed by the TA before scores are finalized.
 
-[This website](www.cmu.edu/teaching/gradescope/) provides students with more information on using Gradescope and how to submit assignments online to Gradescope.
+[This website](https://www.cmu.edu/teaching/gradescope/) provides students with more information on using Gradescope and how to submit assignments online to Gradescope.


### PR DESCRIPTION
The Gradescope link in the syllabus was written as a bare `www.cmu.edu/teaching/gradescope/` with no scheme, so Markdown renders it as a *relative* link. Clicking it from the published site resolves against the course URL and 404s instead of going to CMU's Gradescope page.

Adds the `https://` scheme.

This is the one syllabus change that didn't make it into #10 before that PR merged.